### PR TITLE
Adding more CVM-sizes and a new Disk property entry

### DIFF
--- a/parts/params.t
+++ b/parts/params.t
@@ -6,6 +6,7 @@
     },
     "vmSize": {
       "type": "string",
+      {{GetDefaultVMSize}}
       {{GetAllowedVMSizes}}
       "metadata": {
         "description": "Size of the VM."

--- a/parts/params.t
+++ b/parts/params.t
@@ -6,8 +6,7 @@
     },
     "vmSize": {
       "type": "string",
-      {{GetDefaultVMSize}}
-      {{GetAllowedVMSizes}}
+      {{GetVMSizes}}
       "metadata": {
         "description": "Size of the VM."
       }

--- a/parts/resources.t
+++ b/parts/resources.t
@@ -120,7 +120,7 @@
 {{if HasAttachedOsDisk}}
     {
       "type": "Microsoft.Compute/disks",
-      "apiVersion": "2020-09-30",
+      "apiVersion": "2020-12-01",
       "name": "CustomDisk",
       "location": "[resourceGroup().location]",
 {{if HasAttachedOsDiskVMGS}}
@@ -134,7 +134,9 @@
       "properties": {
         "osType": "[parameters('osType')]",
         "hyperVGeneration": "V2",
-        "securityType" : "{{GetSecurityType}}",
+        "securityProfile":{
+          "securityType" : "{{GetSecurityType}}"
+        },
         "creationData": {
           "createOption": "Import",
           "storageAccountId": "[parameters('osDiskStorageAccountID')]",

--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -20,6 +20,7 @@ type VMConfigurator interface {
 	DefaultOsDiskType() string
 	AllowedOsDiskTypes() []string
 	AllowedVMSizes() []string
+	DefaultVMSize() string
 }
 
 // LoadVMFromFile loads an API Model from a JSON file

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -57,6 +57,11 @@ func GetAllowedVMSizes(vmconf VMConfigurator) string {
 	return getAllowedValues(vmconf.AllowedVMSizes())
 }
 
+// GetAllowedVMSizes returns allowed sizes for VM
+func GetDefaultVMSize(vmconf VMConfigurator) string {
+	return getDefaultValue(vmconf.DefaultVMSize())
+}
+
 // GetOsDiskTypes returns allowed and default OS disk types
 func GetOsDiskTypes(vmconf VMConfigurator) string {
 	return getAllowedDefaultValues(vmconf.AllowedOsDiskTypes(), vmconf.DefaultOsDiskType())

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -52,14 +52,9 @@ func getAllowedDefaultValues(vals []string, def string) string {
 	return getAllowedValues(vals) + "    " + getDefaultValue(def)
 }
 
-// GetAllowedVMSizes returns allowed sizes for VM
-func GetAllowedVMSizes(vmconf VMConfigurator) string {
-	return getAllowedValues(vmconf.AllowedVMSizes())
-}
-
-// GetAllowedVMSizes returns allowed sizes for VM
-func GetDefaultVMSize(vmconf VMConfigurator) string {
-	return getDefaultValue(vmconf.DefaultVMSize())
+// GetVMSizes returns allowed and default sizes for VM
+func GetVMSizes(vmconf VMConfigurator) string {
+	return getAllowedDefaultValues(vmconf.AllowedVMSizes(), vmconf.DefaultVMSize())
 }
 
 // GetOsDiskTypes returns allowed and default OS disk types

--- a/pkg/api/cvm.go
+++ b/pkg/api/cvm.go
@@ -40,8 +40,14 @@ func (h *cvmConfigurator) AllowedVMSizes() []string {
 	return []string{
 		"Standard_DC1as_v4",
 		"Standard_DC2as_v4",
+		"Standard_DC8as_v4",
 		"Standard_DC16as_v4",
 		"Standard_DC32as_v4",
+		"Standard_DC48as_v4",
 		"Standard_DC96as_v4",
 	}
+}
+
+func (h *cvmConfigurator) DefaultVMSize() string {
+	return "Standard_DC1as_v4"
 }

--- a/pkg/api/tvm.go
+++ b/pkg/api/tvm.go
@@ -111,3 +111,7 @@ func (h *tvmConfigurator) AllowedVMSizes() []string {
 		"Standard_D64s_v3",
 	}
 }
+
+func (h *tvmConfigurator) DefaultVMSize() string {
+	return "Standard_DC2s_v2"
+}

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -141,6 +141,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(vm *api.APIModel) template.FuncMa
       }`
 			return fmt.Sprintf(sshTempl, strings.Join(keyData, ",\n"))
 		},
+		"GetDefaultVMSize":func() string {
+			return api.GetDefaultVMSize(vm.VMConfigurator)
+		},
 		"GetAllowedVMSizes": func() string {
 			return api.GetAllowedVMSizes(vm.VMConfigurator)
 		},

--- a/pkg/engine/template_generator.go
+++ b/pkg/engine/template_generator.go
@@ -141,11 +141,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(vm *api.APIModel) template.FuncMa
       }`
 			return fmt.Sprintf(sshTempl, strings.Join(keyData, ",\n"))
 		},
-		"GetDefaultVMSize":func() string {
-			return api.GetDefaultVMSize(vm.VMConfigurator)
-		},
-		"GetAllowedVMSizes": func() string {
-			return api.GetAllowedVMSizes(vm.VMConfigurator)
+		"GetVMSizes": func() string {
+			return api.GetVMSizes(vm.VMConfigurator)
 		},
 		"GetOsDiskTypes": func() string {
 			return api.GetOsDiskTypes(vm.VMConfigurator)


### PR DESCRIPTION
List of changes:
1. Added more CVM Size selections
2. Modified the resource type "Microsoft.Compute/disks"'s securityType to now be enclosed in "securityProfile"
3. Added a new apiVersion for the "Microsoft.Compute/disks"type 
4. Added a default-VM-size field in the resource template. (optional)