### PR TITLE
Adding changes to set default Secure-Boot to true

### DIFF
--- a/parts/params.t
+++ b/parts/params.t
@@ -174,7 +174,8 @@
       "defaultValue": "true",
       "allowedValues": [
         "true",
-         "false"
+        "false",
+        "none"
       ],
       "metadata": {
         "description": "Secure Boot setting of the VM."

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -20,7 +20,7 @@ type OSName string
 
 // SecurityProfile represents VM security profile
 type SecurityProfile struct {
-	SecureBoot bool `json:"secure_boot_enabled,omitempty"`
+	SecureBoot string `json:"secure_boot_enabled,omitempty"`
 	VTPM       bool `json:"vtpm_enabled,omitempty"`
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -21,7 +21,7 @@ type OSName string
 // SecurityProfile represents VM security profile
 type SecurityProfile struct {
 	SecureBoot string `json:"secure_boot_enabled,omitempty"`
-	VTPM       bool `json:"vtpm_enabled,omitempty"`
+	VTPM       string `json:"vtpm_enabled,omitempty"`
 }
 
 // VMProfile represents the definition of a VM

--- a/pkg/api/validate.go
+++ b/pkg/api/validate.go
@@ -102,8 +102,11 @@ func (p *Properties) validateVMProfile(vmconf VMConfigurator) error {
 		if (vm.SecurityProfile.SecureBoot != "true") && (vm.SecurityProfile.SecureBoot != "false") && (vm.SecurityProfile.SecureBoot != "none"){
 			return fmt.Errorf("Invalid Entry! Only the values \"true\", \"false\" and \"none\" are allowed for secure_boot_enabled")
 		}
-		if (vm.SecurityProfile.VTPM != "true") && (vm.SecurityProfile.VTPM != "false") && (vm.SecurityProfile.VTPM != "none"){
-			return fmt.Errorf("Invalid Entry! Only the values \"true\", \"false\" and \"none\" are allowed for VTPM")
+		if (vm.SecurityProfile.VTPM != "true") && (vm.SecurityProfile.VTPM != "false") {
+			return fmt.Errorf("Invalid Entry! Only the values \"true\" and \"false\" are allowed for VTPM")
+		}
+		if (vm.SecurityProfile.SecureBoot == "none") && (vm.SecurityProfile.VTPM == "true") {
+			return fmt.Errorf("Invalid Entry! vTPM cannot be \"true\" when secure-boot is \"none\"")
 		}
 	}
 	if len(vm.OSDiskType) > 0 {

--- a/pkg/api/validate.go
+++ b/pkg/api/validate.go
@@ -98,7 +98,17 @@ func (p *Properties) validateVMProfile(vmconf VMConfigurator) error {
 	if e := validateOSDisk(vm.OSDisk); e != nil {
 		return e
 	}
-
+	if(vm.SecurityProfile == nil) {
+		vm.SecurityProfile = &SecurityProfile{ "true",false}
+	}	else {
+		if len(vm.SecurityProfile.SecureBoot) == 0 {
+			vm.SecurityProfile.SecureBoot = "true"
+		}	else if (vm.SecurityProfile.SecureBoot == "none") {
+				vm.SecurityProfile = nil
+		}	else if (vm.SecurityProfile.SecureBoot != "true") && (vm.SecurityProfile.SecureBoot != "false") {
+				return fmt.Errorf("Invalid Entry! Only the values \"true\", \"false\" and \"none\" are allowed for secure_boot_enabled")
+		}
+	}
 	if len(vm.OSDiskType) > 0 {
 		found := false
 		for _, t := range vmconf.AllowedOsDiskTypes() {

--- a/pkg/api/validate.go
+++ b/pkg/api/validate.go
@@ -98,15 +98,12 @@ func (p *Properties) validateVMProfile(vmconf VMConfigurator) error {
 	if e := validateOSDisk(vm.OSDisk); e != nil {
 		return e
 	}
-	if(vm.SecurityProfile == nil) {
-		vm.SecurityProfile = &SecurityProfile{ "true",false}
-	}	else {
-		if len(vm.SecurityProfile.SecureBoot) == 0 {
-			vm.SecurityProfile.SecureBoot = "true"
-		}	else if (vm.SecurityProfile.SecureBoot == "none") {
-				vm.SecurityProfile = nil
-		}	else if (vm.SecurityProfile.SecureBoot != "true") && (vm.SecurityProfile.SecureBoot != "false") {
-				return fmt.Errorf("Invalid Entry! Only the values \"true\", \"false\" and \"none\" are allowed for secure_boot_enabled")
+	if (vm.SecurityProfile != nil) {
+		if (vm.SecurityProfile.SecureBoot != "true") && (vm.SecurityProfile.SecureBoot != "false") && (vm.SecurityProfile.SecureBoot != "none"){
+			return fmt.Errorf("Invalid Entry! Only the values \"true\", \"false\" and \"none\" are allowed for secure_boot_enabled")
+		}
+		if (vm.SecurityProfile.VTPM != "true") && (vm.SecurityProfile.VTPM != "false") && (vm.SecurityProfile.VTPM != "none"){
+			return fmt.Errorf("Invalid Entry! Only the values \"true\", \"false\" and \"none\" are allowed for VTPM")
 		}
 	}
 	if len(vm.OSDiskType) > 0 {

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -43,13 +43,9 @@ func setPropertiesDefaults(vm *api.APIModel) {
 			if len(vm.Properties.VMProfile.SecurityProfile.VTPM) == 0 {
 				vm.Properties.VMProfile.SecurityProfile.VTPM = "true"
 			}
-			if (vm.Properties.VMProfile.SecurityProfile.SecureBoot == "none")&&(vm.Properties.VMProfile.SecurityProfile.VTPM == "none") {
+			if (vm.Properties.VMProfile.SecurityProfile.SecureBoot == "none") {
 				vm.Properties.VMProfile.SecurityProfile = nil
-			} else if (vm.Properties.VMProfile.SecurityProfile.SecureBoot == "none") {
-				vm.Properties.VMProfile.SecurityProfile.SecureBoot = ""
-			} else if (vm.Properties.VMProfile.SecurityProfile.VTPM == "none") {
-				vm.Properties.VMProfile.SecurityProfile.VTPM = ""
-			}
+			} 
 	}
 }
 

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -34,6 +34,23 @@ func setPropertiesDefaults(vm *api.APIModel) {
 	if len(vm.Properties.VMProfile.OSDiskType) == 0 {
 		vm.Properties.VMProfile.OSDiskType = vm.VMConfigurator.DefaultOsDiskType()
 	}
+	if(vm.Properties.VMProfile.SecurityProfile == nil) {
+		vm.Properties.VMProfile.SecurityProfile = &api.SecurityProfile{ "true","true"}
+	}	else {
+			if len(vm.Properties.VMProfile.SecurityProfile.SecureBoot) == 0 {
+				vm.Properties.VMProfile.SecurityProfile.SecureBoot = "true"
+			}	
+			if len(vm.Properties.VMProfile.SecurityProfile.VTPM) == 0 {
+				vm.Properties.VMProfile.SecurityProfile.VTPM = "true"
+			}
+			if (vm.Properties.VMProfile.SecurityProfile.SecureBoot == "none")&&(vm.Properties.VMProfile.SecurityProfile.VTPM == "none") {
+				vm.Properties.VMProfile.SecurityProfile = nil
+			} else if (vm.Properties.VMProfile.SecurityProfile.SecureBoot == "none") {
+				vm.Properties.VMProfile.SecurityProfile.SecureBoot = ""
+			} else if (vm.Properties.VMProfile.SecurityProfile.VTPM == "none") {
+				vm.Properties.VMProfile.SecurityProfile.VTPM = ""
+			}
+	}
 }
 
 func combineValues(inputs ...string) string {

--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"strconv"
 
 	"github.com/microsoft/acc-vm-engine/pkg/api"
 )
@@ -47,7 +46,7 @@ func getParameters(vm *api.APIModel, generatorCode string) (paramsMap, error) {
 	}
 	if properties.VMProfile.SecurityProfile != nil {
 		addValue(parametersMap, "secureBootEnabled", properties.VMProfile.SecurityProfile.SecureBoot)
-		addValue(parametersMap, "vTPMEnabled", strconv.FormatBool(properties.VMProfile.SecurityProfile.VTPM))
+		addValue(parametersMap, "vTPMEnabled", properties.VMProfile.SecurityProfile.VTPM)
 	}
 	if len(properties.VMProfile.TipNodeSessionID) > 0 {
 		addValue(parametersMap, "tipNodeSessionId", properties.VMProfile.TipNodeSessionID)

--- a/pkg/engine/params.go
+++ b/pkg/engine/params.go
@@ -46,7 +46,7 @@ func getParameters(vm *api.APIModel, generatorCode string) (paramsMap, error) {
 		addValue(parametersMap, "adminPassword", properties.WindowsProfile.AdminPassword)
 	}
 	if properties.VMProfile.SecurityProfile != nil {
-		addValue(parametersMap, "secureBootEnabled", strconv.FormatBool(properties.VMProfile.SecurityProfile.SecureBoot))
+		addValue(parametersMap, "secureBootEnabled", properties.VMProfile.SecurityProfile.SecureBoot)
 		addValue(parametersMap, "vTPMEnabled", strconv.FormatBool(properties.VMProfile.SecurityProfile.VTPM))
 	}
 	if len(properties.VMProfile.TipNodeSessionID) > 0 {

--- a/test/cvm-win.json
+++ b/test/cvm-win.json
@@ -12,10 +12,6 @@
       "tip_node_session_id": "aaa-bbb-ccc-ddd",
       "cluster_name": "QWERTY",
       "vm_size": "Standard_DC1as_v4",
-      "security_profile": {
-        "secure_boot_enabled": "true",
-        "vtpm_enabled": true
-      },
       "ports": [3389],
       "has_dns_name": false
     }

--- a/test/cvm-win.json
+++ b/test/cvm-win.json
@@ -13,7 +13,7 @@
       "cluster_name": "QWERTY",
       "vm_size": "Standard_DC1as_v4",
       "security_profile": {
-        "secure_boot_enabled": true,
+        "secure_boot_enabled": "true",
         "vtpm_enabled": true
       },
       "ports": [3389],

--- a/test/tvm-ub1804.json
+++ b/test/tvm-ub1804.json
@@ -6,10 +6,6 @@
       "os_type": "Linux",
       "os_name": "Ubuntu18.04",
       "vm_size": "Standard_D2s_v3",
-      "security_profile": {
-        "secure_boot_enabled": "true",
-        "vtpm_enabled": true
-      },
       "ports": [22],
       "has_dns_name": false
     },

--- a/test/tvm-ub1804.json
+++ b/test/tvm-ub1804.json
@@ -7,7 +7,7 @@
       "os_name": "Ubuntu18.04",
       "vm_size": "Standard_D2s_v3",
       "security_profile": {
-        "secure_boot_enabled": true,
+        "secure_boot_enabled": "true",
         "vtpm_enabled": true
       },
       "ports": [22],


### PR DESCRIPTION
Changes:
1. Converted Secure_boot_enabled bool to string. And introduced a Secure_boot_enabled ="none" case. That means security-profile is Nil. The table below elaborates functionality.
2. validate.go was updated to introduce 3 valid cases for secure_boot_enabled. And also set default secure_boot_enabled to true when there's no input.
3. params.go was updated to identify SecureBoot as string.
4. cvm-win.json was updated to identify SecureBoot as string.

Cases table:

**|secureboot.--|--Vtpm--|-- Output**
|“true”---------|--true---   | as is
|“false”--------|--true---  | as is
|“True”--------|--false--- | as is
|“False”-------|--false---   | as is     
|EMPTY-------|--ANY----   | Secure-boot set to true
|"none"-------|--ANY----   |  Secure-boot is empty
|ANY---------|--EMPTY--   | vTPM set to true
|"none"-------|--false-   |  Security_profile = nil.